### PR TITLE
Add complete Mockoon API configuration with 29 endpoints

### DIFF
--- a/src/assets/qafilti-mockoon.json
+++ b/src/assets/qafilti-mockoon.json
@@ -1,26 +1,150 @@
 {
   "uuid": "5455c37d-656b-4266-9a5a-c98b9931bc33",
   "lastMigration": 33,
-  "name": "Qafilti",
-  "endpointPrefix": "",
+  "name": "Qafilti API",
+  "endpointPrefix": "api",
   "latency": 0,
-  "port": 3003,
+  "port": 3002,
   "hostname": "",
   "folders": [],
   "routes": [
     {
-      "uuid": "b470bd54-c937-41d4-a9bf-f39363ee4f4b",
+      "uuid": "route-cities-get",
       "type": "http",
-      "documentation": "",
+      "documentation": "Retrieve all cities",
       "method": "get",
-      "endpoint": "",
+      "endpoint": "cities",
       "responses": [
         {
-          "uuid": "5a731dc2-030a-472d-91f5-ca6f22de28cf",
-          "body": "{}",
+          "uuid": "response-cities-get-200",
+          "body": "{\n  \"cities\": [\n    {\"id\": \"1\", \"nameFr\": \"Nouakchott\", \"nameAr\": \"نواكشوط\"},\n    {\"id\": \"2\", \"nameFr\": \"Nouadhibou\", \"nameAr\": \"نواذيبو\"},\n    {\"id\": \"3\", \"nameFr\": \"Rosso\", \"nameAr\": \"روصو\"},\n    {\"id\": \"4\", \"nameFr\": \"Kaédi\", \"nameAr\": \"كيهيدي\"},\n    {\"id\": \"5\", \"nameFr\": \"Zouérat\", \"nameAr\": \"ازويرات\"},\n    {\"id\": \"6\", \"nameFr\": \"Atar\", \"nameAr\": \"أطار\"},\n    {\"id\": \"7\", \"nameFr\": \"Sélibaby\", \"nameAr\": \"سيلبابي\"},\n    {\"id\": \"8\", \"nameFr\": \"Kiffa\", \"nameAr\": \"كيفة\"},\n    {\"id\": \"9\", \"nameFr\": \"Néma\", \"nameAr\": \"النعمة\"},\n    {\"id\": \"10\", \"nameFr\": \"Tidjikja\", \"nameAr\": \"تجكجة\"},\n    {\"id\": \"11\", \"nameFr\": \"Aleg\", \"nameAr\": \"آلاك\"},\n    {\"id\": \"12\", \"nameFr\": \"Boutilimit\", \"nameAr\": \"بوتلميت\"},\n    {\"id\": \"13\", \"nameFr\": \"Akjoujt\", \"nameAr\": \"أكجوجت\"}\n  ]\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-cities-post",
+      "type": "http",
+      "documentation": "Create a new city",
+      "method": "post",
+      "endpoint": "cities",
+      "responses": [
+        {
+          "uuid": "response-cities-post-201",
+          "body": "{\n  \"id\": \"{{faker 'random.number'}}",\n  \"nameFr\": \"{{body 'nameFr'}}\",\n  \"nameAr\": \"{{body 'nameAr'}}\"\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-cities-id-get",
+      "type": "http",
+      "documentation": "Retrieve a city by ID",
+      "method": "get",
+      "endpoint": "cities/:id",
+      "responses": [
+        {
+          "uuid": "response-cities-id-get-200",
+          "body": "{\n  \"id\": \"{{urlParam 'id'}}\",\n  \"nameFr\": \"Nouakchott\",\n  \"nameAr\": \"نواكشوط\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-cities-id-put",
+      "type": "http",
+      "documentation": "Update a city",
+      "method": "put",
+      "endpoint": "cities/:id",
+      "responses": [
+        {
+          "uuid": "response-cities-id-put-200",
+          "body": "{\n  \"id\": \"{{urlParam 'id'}}\",\n  \"nameFr\": \"{{body 'nameFr'}}\",\n  \"nameAr\": \"{{body 'nameAr'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Updated",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-cities-id-delete",
+      "type": "http",
+      "documentation": "Delete a city",
+      "method": "delete",
+      "endpoint": "cities/:id",
+      "responses": [
+        {
+          "uuid": "response-cities-id-delete-204",
+          "body": "",
+          "latency": 0,
+          "statusCode": 204,
+          "label": "Deleted",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -35,16 +159,775 @@
           "callbacks": []
         }
       ],
-      "responseMode": null,
-      "streamingMode": null,
-      "streamingInterval": 0
+      "responseMode": null
+    },
+    {
+      "uuid": "route-cities-search",
+      "type": "http",
+      "documentation": "Search for cities by name",
+      "method": "get",
+      "endpoint": "cities/search",
+      "responses": [
+        {
+          "uuid": "response-cities-search-200",
+          "body": "[\n  {\"id\": \"1\", \"nameFr\": \"Nouakchott\", \"nameAr\": \"نواكشوط\"}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-bus-get",
+      "type": "http",
+      "documentation": "Get all buses",
+      "method": "get",
+      "endpoint": "bus",
+      "responses": [
+        {
+          "uuid": "response-bus-get-200",
+          "body": "[\n  {\"id\": \"B006\", \"license_plate\": \"M33721\", \"status\": \"active\", \"capacity\": 15},\n  {\"id\": \"B007\", \"license_plate\": \"M60123\", \"status\": \"maintenance\", \"capacity\": 12},\n  {\"id\": \"B008\", \"license_plate\": \"M99876\", \"status\": \"active\", \"capacity\": 18}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-trips-get",
+      "type": "http",
+      "documentation": "Get all trips",
+      "method": "get",
+      "endpoint": "trips",
+      "responses": [
+        {
+          "uuid": "response-trips-get-200",
+          "body": "{\n  \"trips\": [\n    {\n      \"tripId\": \"TR001\",\n      \"date\": \"2025-08-31\",\n      \"departureCityId\": \"1\",\n      \"departureCityName\": \"Nouakchott\",\n      \"departureCityNameAr\": \"نواكشوط\",\n      \"arrivalCityId\": \"2\",\n      \"arrivalCityName\": \"Nouadhibou\",\n      \"arrivalCityNameAr\": \"نواذيبو\",\n      \"vehicleId\": \"B006\",\n      \"departureTime\": \"08:00\",\n      \"arrivalTime\": \"14:30\"\n    },\n    {\n      \"tripId\": \"TR002\",\n      \"date\": \"2025-09-01\",\n      \"departureCityId\": \"6\",\n      \"departureCityName\": \"Atar\",\n      \"departureCityNameAr\": \"أطار\",\n      \"arrivalCityId\": \"5\",\n      \"arrivalCityName\": \"Zouérat\",\n      \"arrivalCityNameAr\": \"ازويرات\",\n      \"vehicleId\": \"B008\",\n      \"departureTime\": \"10:00\",\n      \"arrivalTime\": \"11:30\"\n    },\n    {\n      \"tripId\": \"TR003\",\n      \"date\": \"2025-09-02\",\n      \"departureCityId\": \"4\",\n      \"departureCityName\": \"Kaédi\",\n      \"departureCityNameAr\": \"كيهيدي\",\n      \"arrivalCityId\": \"7\",\n      \"arrivalCityName\": \"Sélibaby\",\n      \"arrivalCityNameAr\": \"سيلبابي\",\n      \"vehicleId\": \"B007\",\n      \"departureTime\": \"15:00\",\n      \"arrivalTime\": \"17:00\"\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-reservation-get",
+      "type": "http",
+      "documentation": "Get all reservations",
+      "method": "get",
+      "endpoint": "reservation",
+      "responses": [
+        {
+          "uuid": "response-reservation-get-200",
+          "body": "{\n  \"reservations\": [\n    {\n      \"reservationId\": \"RES001\",\n      \"tripId\": \"TR001\",\n      \"netAmount\": 1500,\n      \"seatNumber\": \"12A\",\n      \"passengerName\": \"Aliou Diallo\",\n      \"passengerPhone\": \"222-44-55-66-77\",\n      \"status\": \"CONFIRMED\",\n      \"createdAt\": \"2025-08-29T10:00:00Z\"\n    },\n    {\n      \"reservationId\": \"RES002\",\n      \"tripId\": \"TR002\",\n      \"netAmount\": 1000,\n      \"seatNumber\": \"5C\",\n      \"passengerName\": \"Fatou Fall\",\n      \"passengerPhone\": \"222-88-77-66-55\",\n      \"status\": \"PENDING\",\n      \"createdAt\": \"2025-08-30T12:30:00Z\"\n    },\n    {\n      \"reservationId\": \"RES003\",\n      \"tripId\": \"TR001\",\n      \"netAmount\": 1500,\n      \"seatNumber\": \"15B\",\n      \"passengerName\": \"Ahmed Ould Mohamed\",\n      \"passengerPhone\": \"222-11-22-33-44\",\n      \"status\": \"CREATED\",\n      \"createdAt\": \"2025-08-31T14:00:00Z\"\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-passagers-get",
+      "type": "http",
+      "documentation": "Get all passengers",
+      "method": "get",
+      "endpoint": "passagers",
+      "responses": [
+        {
+          "uuid": "response-passagers-get-200",
+          "body": "[\n  {\"id\": 1, \"nom\": \"Jean Dupont\", \"telephone\": \"0601020304\", \"document\": \"CIN123456\"},\n  {\"id\": 2, \"nom\": \"Marie Curie\", \"telephone\": \"0605060708\", \"document\": \"CIN654321\"},\n  {\"id\": 3, \"nom\": \"Ali Ben Ali\", \"telephone\": \"0611121314\", \"document\": \"CIN112233\"}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-passagers-post",
+      "type": "http",
+      "documentation": "Create a new passenger",
+      "method": "post",
+      "endpoint": "passagers",
+      "responses": [
+        {
+          "uuid": "response-passagers-post-201",
+          "body": "{\n  \"id\": {{faker 'random.number'}},\n  \"nom\": \"{{body 'nom'}}\",\n  \"telephone\": \"{{body 'telephone'}}\",\n  \"document\": \"{{body 'document'}}\"\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-passagers-id-put",
+      "type": "http",
+      "documentation": "Update a passenger",
+      "method": "put",
+      "endpoint": "passagers/:id",
+      "responses": [
+        {
+          "uuid": "response-passagers-id-put-200",
+          "body": "{\n  \"id\": {{urlParam 'id'}},\n  \"nom\": \"{{body 'nom'}}\",\n  \"telephone\": \"{{body 'telephone'}}\",\n  \"document\": \"{{body 'document'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Updated",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-passagers-id-delete",
+      "type": "http",
+      "documentation": "Delete a passenger",
+      "method": "delete",
+      "endpoint": "passagers/:id",
+      "responses": [
+        {
+          "uuid": "response-passagers-id-delete-204",
+          "body": "",
+          "latency": 0,
+          "statusCode": 204,
+          "label": "Deleted",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-colis-get",
+      "type": "http",
+      "documentation": "Get all packages",
+      "method": "get",
+      "endpoint": "colis",
+      "responses": [
+        {
+          "uuid": "response-colis-get-200",
+          "body": "[\n  {\"id\": 1, \"code\": \"CLS-0001\", \"expediteur\": \"Nadia\", \"destinataire\": \"Karim\", \"poids\": 3.2, \"tarif\": 8, \"statut\": \"En transit\"},\n  {\"id\": 2, \"code\": \"CLS-0002\", \"expediteur\": \"Fatima\", \"destinataire\": \"Hassan\", \"poids\": 5.0, \"tarif\": 12, \"statut\": \"Livré\"}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-colis-post",
+      "type": "http",
+      "documentation": "Create a new package",
+      "method": "post",
+      "endpoint": "colis",
+      "responses": [
+        {
+          "uuid": "response-colis-post-201",
+          "body": "{\n  \"id\": {{faker 'random.number'}},\n  \"code\": \"CLS-{{faker 'random.number'}}\",\n  \"expediteur\": \"{{body 'expediteur'}}\",\n  \"destinataire\": \"{{body 'destinataire'}}\",\n  \"poids\": {{body 'poids'}},\n  \"tarif\": {{body 'tarif'}},\n  \"statut\": \"{{body 'statut'}}\"\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-colis-id-put",
+      "type": "http",
+      "documentation": "Update a package",
+      "method": "put",
+      "endpoint": "colis/:id",
+      "responses": [
+        {
+          "uuid": "response-colis-id-put-200",
+          "body": "{\n  \"id\": {{urlParam 'id'}},\n  \"code\": \"{{body 'code'}}\",\n  \"expediteur\": \"{{body 'expediteur'}}\",\n  \"destinataire\": \"{{body 'destinataire'}}\",\n  \"poids\": {{body 'poids'}},\n  \"tarif\": {{body 'tarif'}},\n  \"statut\": \"{{body 'statut'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Updated",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-colis-id-delete",
+      "type": "http",
+      "documentation": "Delete a package",
+      "method": "delete",
+      "endpoint": "colis/:id",
+      "responses": [
+        {
+          "uuid": "response-colis-id-delete-204",
+          "body": "",
+          "latency": 0,
+          "statusCode": 204,
+          "label": "Deleted",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-paiements-get",
+      "type": "http",
+      "documentation": "Get all payments",
+      "method": "get",
+      "endpoint": "paiements",
+      "responses": [
+        {
+          "uuid": "response-paiements-get-200",
+          "body": "[\n  {\"ref\": \"12345\", \"type\": \"Acompte\", \"montant\": 500, \"mode\": \"Carte bancaire\", \"note\": \"Premier paiement\"},\n  {\"ref\": \"67890\", \"type\": \"Solde\", \"montant\": 1500, \"mode\": \"Virement\", \"note\": \"Paiement final\"}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-paiements-post",
+      "type": "http",
+      "documentation": "Create a new payment",
+      "method": "post",
+      "endpoint": "paiements",
+      "responses": [
+        {
+          "uuid": "response-paiements-post-201",
+          "body": "{\n  \"ref\": \"{{faker 'random.number'}}\",\n  \"type\": \"{{body 'type'}}\",\n  \"montant\": {{body 'montant'}},\n  \"mode\": \"{{body 'mode'}}\",\n  \"note\": \"{{body 'note'}}\"\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-rapports-kpis",
+      "type": "http",
+      "documentation": "Get KPIs for reports",
+      "method": "get",
+      "endpoint": "rapports/kpis",
+      "responses": [
+        {
+          "uuid": "response-rapports-kpis-200",
+          "body": "{\n  \"billets\": 3200,\n  \"colis\": 860,\n  \"fillRate\": 78,\n  \"resaToday\": 12,\n  \"parcelsTransit\": 27,\n  \"revenueMonth\": 15840\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-rapports-revenus",
+      "type": "http",
+      "documentation": "Get revenue by trip",
+      "method": "get",
+      "endpoint": "rapports/revenus",
+      "responses": [
+        {
+          "uuid": "response-rapports-revenus-200",
+          "body": "[\n  {\"trajet\": \"Casa → Rabat\", \"count\": 120, \"revenu\": 1440},\n  {\"trajet\": \"Rabat → Fès\", \"count\": 80, \"revenu\": 1440},\n  {\"trajet\": \"Casa → Marrakech\", \"count\": 95, \"revenu\": 1900}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-vehicules-get",
+      "type": "http",
+      "documentation": "Get all vehicles",
+      "method": "get",
+      "endpoint": "vehicules",
+      "responses": [
+        {
+          "uuid": "response-vehicules-get-200",
+          "body": "[\n  {\"id\": 1, \"matricule\": \"ABC-123\", \"modele\": \"Mercedes Sprinter\", \"capacite\": 18},\n  {\"id\": 2, \"matricule\": \"DEF-456\", \"modele\": \"Renault Master\", \"capacite\": 15}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-vehicules-post",
+      "type": "http",
+      "documentation": "Create a new vehicle",
+      "method": "post",
+      "endpoint": "vehicules",
+      "responses": [
+        {
+          "uuid": "response-vehicules-post-201",
+          "body": "{\n  \"id\": {{faker 'random.number'}},\n  \"matricule\": \"{{body 'matricule'}}\",\n  \"modele\": \"{{body 'modele'}}\",\n  \"capacite\": {{body 'capacite'}}\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-vehicules-id-put",
+      "type": "http",
+      "documentation": "Update a vehicle",
+      "method": "put",
+      "endpoint": "vehicules/:id",
+      "responses": [
+        {
+          "uuid": "response-vehicules-id-put-200",
+          "body": "{\n  \"id\": {{urlParam 'id'}},\n  \"matricule\": \"{{body 'matricule'}}\",\n  \"modele\": \"{{body 'modele'}}\",\n  \"capacite\": {{body 'capacite'}}\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Updated",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-vehicules-id-delete",
+      "type": "http",
+      "documentation": "Delete a vehicle",
+      "method": "delete",
+      "endpoint": "vehicules/:id",
+      "responses": [
+        {
+          "uuid": "response-vehicules-id-delete-204",
+          "body": "",
+          "latency": 0,
+          "statusCode": 204,
+          "label": "Deleted",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-tarifs-get",
+      "type": "http",
+      "documentation": "Get all tariffs",
+      "method": "get",
+      "endpoint": "tarifs",
+      "responses": [
+        {
+          "uuid": "response-tarifs-get-200",
+          "body": "[\n  {\"id\": 1, \"trajet\": \"Casa → Rabat\", \"prix\": 12},\n  {\"id\": 2, \"trajet\": \"Rabat → Fès\", \"prix\": 18},\n  {\"id\": 3, \"trajet\": \"Casa → Marrakech\", \"prix\": 20}\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Success",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-tarifs-post",
+      "type": "http",
+      "documentation": "Create a new tariff",
+      "method": "post",
+      "endpoint": "tarifs",
+      "responses": [
+        {
+          "uuid": "response-tarifs-post-201",
+          "body": "{\n  \"id\": {{faker 'random.number'}},\n  \"trajet\": \"{{body 'trajet'}}\",\n  \"prix\": {{body 'prix'}}\n}",
+          "latency": 0,
+          "statusCode": 201,
+          "label": "Created",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-tarifs-id-put",
+      "type": "http",
+      "documentation": "Update a tariff",
+      "method": "put",
+      "endpoint": "tarifs/:id",
+      "responses": [
+        {
+          "uuid": "response-tarifs-id-put-200",
+          "body": "{\n  \"id\": {{urlParam 'id'}},\n  \"trajet\": \"{{body 'trajet'}}\",\n  \"prix\": {{body 'prix'}}\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Updated",
+          "headers": [
+            {"key": "Content-Type", "value": "application/json"}
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    },
+    {
+      "uuid": "route-tarifs-id-delete",
+      "type": "http",
+      "documentation": "Delete a tariff",
+      "method": "delete",
+      "endpoint": "tarifs/:id",
+      "responses": [
+        {
+          "uuid": "response-tarifs-id-delete-204",
+          "body": "",
+          "latency": 0,
+          "statusCode": 204,
+          "label": "Deleted",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
     }
   ],
   "rootChildren": [
-    {
-      "type": "route",
-      "uuid": "b470bd54-c937-41d4-a9bf-f39363ee4f4b"
-    }
+    {"type": "route", "uuid": "route-cities-get"},
+    {"type": "route", "uuid": "route-cities-post"},
+    {"type": "route", "uuid": "route-cities-id-get"},
+    {"type": "route", "uuid": "route-cities-id-put"},
+    {"type": "route", "uuid": "route-cities-id-delete"},
+    {"type": "route", "uuid": "route-cities-search"},
+    {"type": "route", "uuid": "route-bus-get"},
+    {"type": "route", "uuid": "route-trips-get"},
+    {"type": "route", "uuid": "route-reservation-get"},
+    {"type": "route", "uuid": "route-passagers-get"},
+    {"type": "route", "uuid": "route-passagers-post"},
+    {"type": "route", "uuid": "route-passagers-id-put"},
+    {"type": "route", "uuid": "route-passagers-id-delete"},
+    {"type": "route", "uuid": "route-colis-get"},
+    {"type": "route", "uuid": "route-colis-post"},
+    {"type": "route", "uuid": "route-colis-id-put"},
+    {"type": "route", "uuid": "route-colis-id-delete"},
+    {"type": "route", "uuid": "route-paiements-get"},
+    {"type": "route", "uuid": "route-paiements-post"},
+    {"type": "route", "uuid": "route-rapports-kpis"},
+    {"type": "route", "uuid": "route-rapports-revenus"},
+    {"type": "route", "uuid": "route-vehicules-get"},
+    {"type": "route", "uuid": "route-vehicules-post"},
+    {"type": "route", "uuid": "route-vehicules-id-put"},
+    {"type": "route", "uuid": "route-vehicules-id-delete"},
+    {"type": "route", "uuid": "route-tarifs-get"},
+    {"type": "route", "uuid": "route-tarifs-post"},
+    {"type": "route", "uuid": "route-tarifs-id-put"},
+    {"type": "route", "uuid": "route-tarifs-id-delete"}
   ],
   "proxyMode": false,
   "proxyHost": "",
@@ -60,35 +943,13 @@
   },
   "cors": true,
   "headers": [
-    {
-      "key": "Content-Type",
-      "value": "application/json"
-    },
-    {
-      "key": "Access-Control-Allow-Origin",
-      "value": "*"
-    },
-    {
-      "key": "Access-Control-Allow-Methods",
-      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
-    },
-    {
-      "key": "Access-Control-Allow-Headers",
-      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
-    }
+    {"key": "Content-Type", "value": "application/json"},
+    {"key": "Access-Control-Allow-Origin", "value": "*"},
+    {"key": "Access-Control-Allow-Methods", "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"},
+    {"key": "Access-Control-Allow-Headers", "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"}
   ],
-  "proxyReqHeaders": [
-    {
-      "key": "",
-      "value": ""
-    }
-  ],
-  "proxyResHeaders": [
-    {
-      "key": "",
-      "value": ""
-    }
-  ],
+  "proxyReqHeaders": [{"key": "", "value": ""}],
+  "proxyResHeaders": [{"key": "", "value": ""}],
   "data": [],
   "callbacks": []
 }


### PR DESCRIPTION
- Implement OpenAPI endpoints: cities (CRUD + search), bus, trips, reservations
- Add frontend-specific endpoints: passagers, colis, paiements, rapports
- Add admin endpoints: vehicules, tarifs (full CRUD)
- Configure port 3002 with CORS enabled
- Include all mock data for testing frontend features

🤖 Generated with [Claude Code](https://claude.com/claude-code)