### PR TITLE
docs: Update documentation for bilingual ticket printing feature

### DIFF
--- a/DOCUMENTATION_FONCTIONNELLE.md
+++ b/DOCUMENTATION_FONCTIONNELLE.md
@@ -320,11 +320,50 @@ Les réservations sont créées en statut **Brouillon** par l'agent comptoir.
 - **Brouillon** : Réservation créée par le comptoir, en attente de paiement
 - **Confirmée** : Réservation payée et validée par le caissier
 
-#### 🖨️ Imprimer une Réservation
+#### 🖨️ Imprimer un Ticket de Réservation
 
-1. Cliquer sur l'icône **Imprimer**
-2. La fenêtre d'impression du navigateur s'ouvre
-3. Sélectionner votre imprimante ou enregistrer en PDF
+**Rôle** : Principalement Agent Caissier (après confirmation), Administrateur
+
+L'application génère automatiquement un **ticket bilingue** (Français/Arabe) professionnel pour chaque réservation.
+
+**Format du ticket** :
+- **Taille** : 80mm (format imprimante thermique standard)
+- **Layout** : Bilingue côte-à-côte
+  - Français à gauche (lecture normale)
+  - Arabe à droite (lecture RTL - de droite à gauche)
+- **Branding** : Logo QAFILTI en français et arabe
+
+**Informations affichées sur le ticket** :
+- Code de réservation
+- Statut (Brouillon/Confirmée → مسودة/مؤكدة)
+- Nom du passager (الاسم)
+- Téléphone (الهاتف)
+- Trajet : Origine → Destination (الرحلة)
+- Date et heure de départ (التاريخ)
+- Numéro de place (رقم المقعد)
+- Montant (المبلغ)
+
+**Comment imprimer** :
+1. Cliquer sur l'icône **Imprimer** (🖨️) sur la ligne de la réservation
+2. Le ticket bilingue s'affiche automatiquement
+3. La fenêtre d'impression du navigateur s'ouvre
+4. Sélectionner votre imprimante thermique ou enregistrer en PDF
+5. Cliquer sur **Imprimer**
+
+**Workflow typique (Caissier)** :
+1. Client présente sa réservation en brouillon
+2. Caissier encaisse le paiement
+3. Caissier confirme la réservation (clic sur ✅)
+4. Caissier **imprime le ticket bilingue** (clic sur 🖨️)
+5. Caissier remet le ticket imprimé au client
+
+**💡 Conseils d'impression** :
+- **Imprimante thermique** : Sélectionnez format 80mm dans les paramètres d'impression
+- **Imprimante classique** : Le ticket s'adaptera à la page A4
+- **PDF** : Utile pour archivage numérique
+- Le ticket est optimisé pour l'impression : seul le ticket s'imprimera, pas le reste de la page
+
+**Accessibilité** : Le format bilingue permet de servir les clients francophones et arabophones avec le même ticket professionnel
 
 #### 🔍 Rechercher une Réservation
 
@@ -837,14 +876,17 @@ Pour suggérer une amélioration :
 
 | Terme | Définition |
 |-------|------------|
-| **Brouillon** | Réservation non confirmée, provisoire |
-| **Confirmée** | Réservation validée et payée |
+| **Brouillon** | Réservation non confirmée, provisoire (مسودة) |
+| **Confirmée** | Réservation validée et payée (مؤكدة) |
+| **Ticket bilingue** | Document d'impression en français et arabe pour réservations |
 | **En transit** | Colis en cours d'acheminement |
 | **Livré** | Colis remis au destinataire |
 | **KPI** | Indicateur clé de performance |
 | **Acompte** | Paiement partiel initial |
 | **Solde** | Paiement final du reste dû |
 | **RBAC** | Contrôle d'accès basé sur les rôles |
+| **RTL** | Right-to-Left (lecture de droite à gauche pour l'arabe) |
+| **Format thermique 80mm** | Format standard pour imprimantes à ticket (caisses, transport) |
 
 ---
 
@@ -869,14 +911,23 @@ Pour suggérer une amélioration :
 
 ---
 
-**Documentation mise à jour le** : 25 Octobre 2024
-**Version de l'application** : 0.0.3
+**Documentation mise à jour le** : 26 Octobre 2025
+**Version de l'application** : 0.0.4
 
 ---
 
 ## Historique des Versions
 
-### Version 0.0.3 (Actuelle)
+### Version 0.0.4 (Actuelle)
+- ✅ Migration complète vers API Mockoon (29 endpoints)
+- ✅ Chargement automatique des données depuis l'API
+- ✅ **Ticket de réservation bilingue (Français/Arabe)**
+- ✅ Format thermique 80mm avec support RTL pour l'arabe
+- ✅ Workflow réservations corrigé (Comptoir → Caissier)
+- ✅ Caissier confirme après paiement et imprime ticket
+- ✅ Documentation complète mise à jour
+
+### Version 0.0.3
 - ✅ Système de rôles et permissions
 - ✅ Comptes de test disponibles
 - ✅ Amélioration UI page de connexion

--- a/DOCUMENTATION_TECHNIQUE.md
+++ b/DOCUMENTATION_TECHNIQUE.md
@@ -499,6 +499,138 @@ export class FeatureComponent {
 | AdminComponent | `/admin` | Administration système |
 | LoginComponent | `/login` | Authentification |
 | RegisterComponent | `/inscription` | Inscription |
+| TicketPrintComponent | (pas de route) | Impression ticket bilingue |
+
+### Composant Spécialisé : TicketPrintComponent
+
+**Fichier** : `src/app/features/reservations/ticket-print.component.ts`
+
+**Type** : Composant standalone utilitaire
+
+**Responsabilité** : Afficher et imprimer un ticket de réservation bilingue (Français/Arabe)
+
+**Utilisation** : Intégré dans ReservationsComponent pour l'impression
+
+**Caractéristiques** :
+
+- **Format** : 80mm (papier imprimante thermique)
+- **Layout bilingue** :
+  - Français à gauche (LTR)
+  - Arabe à droite (RTL avec `direction: rtl`)
+- **Branding** : Logo QAFILTI en français et arabe
+- **Champs affichés** :
+  - Code réservation
+  - Statut (Brouillon/Confirmée)
+  - Nom et téléphone du passager
+  - Trajet (origine → destination)
+  - Date et heure de départ
+  - Numéro de place
+  - Montant (EUR)
+
+**Interface d'entrée** :
+```typescript
+@Input() reservation?: Reservation;
+```
+
+**Méthodes** :
+```typescript
+// Conversion du statut en français
+getStatus(): string {
+  if (!this.reservation?.statut) return '-';
+  const statusMap: { [key: string]: string } = {
+    'Brouillon': 'Brouillon',
+    'Confirmée': 'Confirmée',
+    'CONFIRMED': 'Confirmée',
+    'PENDING': 'En attente',
+    'CREATED': 'Créée'
+  };
+  return statusMap[this.reservation.statut] || this.reservation.statut;
+}
+
+// Conversion du statut en arabe
+getStatusAr(): string {
+  if (!this.reservation?.statut) return '-';
+  const statusMap: { [key: string]: string } = {
+    'Brouillon': 'مسودة',
+    'Confirmée': 'مؤكدة',
+    'CONFIRMED': 'مؤكدة',
+    'PENDING': 'قيد الانتظار',
+    'CREATED': 'تم الإنشاء'
+  };
+  return statusMap[this.reservation.statut] || this.reservation.statut;
+}
+```
+
+**Styles d'impression** :
+```css
+@media print {
+  /* Masquer tout le contenu de la page */
+  body * {
+    visibility: hidden;
+  }
+
+  /* Afficher uniquement le ticket */
+  .ticket-container,
+  .ticket-container * {
+    visibility: visible;
+  }
+
+  /* Configuration page */
+  @page {
+    size: 80mm auto;
+    margin: 0;
+  }
+}
+```
+
+**Intégration dans ReservationsComponent** :
+```typescript
+// reservations.component.ts
+export class ReservationsComponent {
+  ticketToPrint?: Reservation;  // Réservation à imprimer
+
+  print(r: Reservation) {
+    // Charger la réservation dans le ticket
+    this.ticketToPrint = r;
+
+    // Attendre le rendu puis imprimer
+    setTimeout(() => {
+      window.print();
+      // Nettoyer après impression
+      setTimeout(() => this.ticketToPrint = undefined, 100);
+    }, 100);
+  }
+}
+```
+
+```html
+<!-- reservations.component.html -->
+<!-- Ticket caché à l'écran, visible uniquement lors de l'impression -->
+<app-ticket-print [reservation]="ticketToPrint"></app-ticket-print>
+```
+
+```css
+/* reservations.component.css */
+app-ticket-print {
+  display: none;  /* Caché à l'écran */
+}
+
+@media print {
+  app-ticket-print {
+    display: block;  /* Visible lors de l'impression */
+  }
+}
+```
+
+**Workflow d'impression** :
+1. Utilisateur clique sur bouton "Imprimer" (icône `pi-print`)
+2. ReservationsComponent charge la réservation dans `ticketToPrint`
+3. TicketPrintComponent s'affiche (invisible à l'écran)
+4. `window.print()` ouvre la boîte de dialogue d'impression
+5. Seul le ticket est visible dans l'aperçu/impression
+6. Après impression, `ticketToPrint` est réinitialisé à `undefined`
+
+**Rôle utilisateur** : Principalement utilisé par le **Caissier** après confirmation de réservation et paiement
 
 ---
 
@@ -1063,7 +1195,15 @@ Pour toute question technique, consulter :
 
 ## Changelog Technique
 
-### v0.0.3 (Actuel)
+### v0.0.4 (Actuel)
+- ✅ Migration complète vers Mockoon API (29 endpoints)
+- ✅ Tous les services utilisent HttpClient pour charger les données
+- ✅ Correction workflow réservations (Comptoir → Caissier)
+- ✅ **Ticket d'impression bilingue (FR/AR)** pour réservations
+- ✅ Format thermique 80mm avec layout RTL pour arabe
+- ✅ Documentation technique et fonctionnelle mise à jour
+
+### v0.0.3
 - ✅ Système RBAC complet (3 rôles)
 - ✅ Guards (auth + role)
 - ✅ Persistance session localStorage
@@ -1083,6 +1223,6 @@ Pour toute question technique, consulter :
 
 ---
 
-**Documentation mise à jour le** : 25 Octobre 2024
-**Version de l'application** : 0.0.3
+**Documentation mise à jour le** : 26 Octobre 2025
+**Version de l'application** : 0.0.4
 **Angular** : 20.2.0


### PR DESCRIPTION
Technical Documentation (DOCUMENTATION_TECHNIQUE.md):
- Add TicketPrintComponent section with detailed implementation
- Document bilingual layout (French LTR + Arabic RTL)
- Explain 80mm thermal printer format
- Add print workflow and integration details
- Update changelog to v0.0.4 with ticket feature

Functional Documentation (DOCUMENTATION_FONCTIONNELLE.md):
- Add comprehensive ticket printing section in Reservations
- Detail ticket format: French/Arabic side-by-side
- Explain Caissier workflow: confirm → print → deliver ticket
- Add printing instructions for thermal vs regular printers
- Update glossary with bilingual terms and RTL definition
- Update version history to 0.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)