### PR TITLE
fix: Correct JSON syntax error in Mockoon configuration file

### DIFF
--- a/src/assets/qafilti-mockoon.json
+++ b/src/assets/qafilti-mockoon.json
@@ -48,7 +48,7 @@
       "responses": [
         {
           "uuid": "response-cities-post-201",
-          "body": "{\n  \"id\": \"{{faker 'random.number'}}",\n  \"nameFr\": \"{{body 'nameFr'}}\",\n  \"nameAr\": \"{{body 'nameAr'}}\"\n}",
+          "body": "{\n  \"id\": \"{{faker 'random.number'}}\",\n  \"nameFr\": \"{{body 'nameFr'}}\",\n  \"nameAr\": \"{{body 'nameAr'}}\"\n}",
           "latency": 0,
           "statusCode": 201,
           "label": "Created",


### PR DESCRIPTION
- Fix missing closing quote in cities POST endpoint response body
- Corrected line 51: added missing quote after {{faker 'random.number'}}
- File now passes JSON validation
- Mockoon CLI can now successfully start the mock server

🤖 Generated with [Claude Code](https://claude.com/claude-code)