### PR TITLE
test: Add test data to all services to diagnose display issue

### DIFF
--- a/src/app/core/services/bus.service.ts
+++ b/src/app/core/services/bus.service.ts
@@ -24,6 +24,13 @@ export class BusService {
   );
 
   constructor() {
+    console.log('[BusService] CONSTRUCTOR called');
+    // Add test data immediately
+    this._buses.set([
+      { id: 'TEST001', license_plate: 'TEST-123', status: 'active', capacity: 20 }
+    ]);
+    console.log('[BusService] Test data set, count:', this._buses().length);
+
     this.loadBuses();
   }
 

--- a/src/app/core/services/cities.service.ts
+++ b/src/app/core/services/cities.service.ts
@@ -20,6 +20,13 @@ export class CitiesService {
   readonly citiesCount = computed(() => this._cities().length);
 
   constructor() {
+    console.log('[CitiesService] CONSTRUCTOR called');
+    // Add test data immediately
+    this._cities.set([
+      { id: '999', nameFr: 'Test Ville', nameAr: 'مدينة الاختبار' }
+    ]);
+    console.log('[CitiesService] Test data set, count:', this._cities().length);
+
     this.loadCities();
   }
 

--- a/src/app/core/services/colis.service.ts
+++ b/src/app/core/services/colis.service.ts
@@ -26,6 +26,13 @@ export class ColisService {
   readonly deliveredCount = computed(() => this._colis().filter(c => c.statut === 'Livré').length);
 
   constructor() {
+    console.log('[ColisService] CONSTRUCTOR called');
+    // Add test data immediately
+    this._colis.set([
+      { id: 999, code: 'TEST-001', expediteur: 'Test Exp', destinataire: 'Test Dest', poids: 5, tarif: 50, statut: 'En transit' }
+    ]);
+    console.log('[ColisService] Test data set, count:', this._colis().length);
+
     this.loadColis();
   }
 

--- a/src/app/core/services/passagers.service.ts
+++ b/src/app/core/services/passagers.service.ts
@@ -21,6 +21,13 @@ export class PassagersService {
   readonly passagersCount = computed(() => this._passagers().length);
 
   constructor() {
+    console.log('[PassagersService] CONSTRUCTOR called');
+    // Add test data immediately
+    this._passagers.set([
+      { id: 999, nom: 'Test Passager', telephone: '0600000000', document: 'TEST123' }
+    ]);
+    console.log('[PassagersService] Test data set, count:', this._passagers().length);
+
     this.loadPassagers();
   }
 

--- a/src/app/core/services/reservations.service.ts
+++ b/src/app/core/services/reservations.service.ts
@@ -44,6 +44,22 @@ export class ReservationsService {
   });
 
   constructor() {
+    console.log('[ReservationsService] CONSTRUCTOR called');
+    // Add test data immediately to verify display works
+    this._reservations.set([
+      {
+        id: 999,
+        code: 'TEST-001',
+        passager: 'Test Passager',
+        trajet: 'Test Trajet',
+        date: new Date(),
+        prix: 100,
+        statut: 'Brouillon'
+      }
+    ]);
+    console.log('[ReservationsService] Test data set, count:', this._reservations().length);
+
+    // Then try to load from API
     this.loadReservations();
   }
 

--- a/src/app/core/services/trips.service.ts
+++ b/src/app/core/services/trips.service.ts
@@ -32,6 +32,13 @@ export class TripsService {
   });
 
   constructor() {
+    console.log('[TripsService] CONSTRUCTOR called');
+    // Add test data immediately
+    this._trips.set([
+      { tripId: 'TEST001', date: '2025-01-01', departureCityName: 'Test A', arrivalCityName: 'Test B', vehicleId: 'V001' }
+    ]);
+    console.log('[TripsService] Test data set, count:', this._trips().length);
+
     this.loadTrips();
   }
 


### PR DESCRIPTION
Added immediate test data initialization in service constructors to:
1. Verify that data tables can display data correctly
2. Confirm that Angular signals are working
3. Isolate whether the issue is with HTTP calls or with display

Each service now:
- Logs when constructor is called
- Sets test data immediately (1 test item)
- Logs the count of test data set
- Then attempts to load from Mockoon API

Services updated with test data:
- ReservationsService: TEST-001 reservation
- PassagersService: Test Passager
- ColisService: TEST-001 colis
- BusService: TEST001 bus
- CitiesService: Test Ville
- TripsService: TEST001 trip

This will show:
- If tables display test data → HTTP/Mockoon issue
- If tables still empty → Display/template issue

Check browser console for:
- [ServiceName] CONSTRUCTOR called
- [ServiceName] Test data set, count: 1
- [ServiceName] Loading... from API
- [ServiceName] Received data: [...]

🤖 Generated with [Claude Code](https://claude.com/claude-code)