### PR TITLE
fix: Convert date string to Date object in reservations edit form

### DIFF
--- a/src/app/features/reservations/reservations.component.ts
+++ b/src/app/features/reservations/reservations.component.ts
@@ -61,7 +61,10 @@ export class ReservationsComponent {
 
   edit(r: Reservation) {
     this.currentId = r.id || r.reservationId;
-    this.form = { ...r };
+    this.form = {
+      ...r,
+      date: r.date ? (typeof r.date === 'string' ? new Date(r.date) : r.date) : undefined
+    };
     this.dialog = true;
   }
 


### PR DESCRIPTION
- When editing a reservation, convert the date string from API to Date object
- This fixes the issue where the date field appeared empty in the edit dialog
- The datepicker component (p-datepicker) requires a Date object, not a string
- Added type checking to handle both string and Date types safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)