### PR TITLE
fix: Map createdAt to date field in reservations service

### DIFF
--- a/src/app/core/services/reservations.service.ts
+++ b/src/app/core/services/reservations.service.ts
@@ -62,12 +62,14 @@ export class ReservationsService {
             code: r.code || r.reservationId || '',
             passager: r.passager || r.passengerName || '',
             trajet: r.trajet || r.tripId || 'Trajet à définir',
+            date: r.date || r.createdAt || new Date().toISOString(),
             prix: r.prix ?? r.netAmount ?? 0,
             statut: this.mapStatus(r.status || r.statut),
             // Keep original fields for compatibility
             reservationId: r.reservationId,
             passengerName: r.passengerName,
-            netAmount: r.netAmount
+            netAmount: r.netAmount,
+            createdAt: r.createdAt
           }));
           console.log('[ReservationsService] Mapped reservations:', mappedReservations);
           console.log('[ReservationsService] Setting', mappedReservations.length, 'reservations');


### PR DESCRIPTION
- Add date field mapping in reservations service to use createdAt from API
- Mock data has createdAt but not date, now properly mapped
- Fallback order: r.date -> r.createdAt -> current date
- This fixes the issue where date column was empty in reservations table
- Date now displays correctly in both table and edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)