### PR TITLE
fix: Change tooltip to pTooltip for PrimeNG compatibility

### DIFF
--- a/src/app/features/reservations/reservations.component.html
+++ b/src/app/features/reservations/reservations.component.html
@@ -27,20 +27,20 @@
           icon="pi pi-check"
           severity="success"
           (click)="confirm(r)"
-          tooltip="Valider (Caissier uniquement)">
+          pTooltip="Valider (Caissier uniquement)">
         </button>
         <button pButton
           *ngIf="canPrint()"
           icon="pi pi-print"
           (click)="print(r)"
-          tooltip="Imprimer (Caissier uniquement)">
+          pTooltip="Imprimer (Caissier uniquement)">
         </button>
         <button pButton
           *ngIf="canDelete(r)"
           icon="pi pi-times"
           (click)="remove(r)"
           severity="danger"
-          [tooltip]="r.statut === 'Validée' ? 'Seul le caissier peut supprimer une réservation validée' : 'Supprimer'">
+          [pTooltip]="r.statut === 'Validée' ? 'Seul le caissier peut supprimer une réservation validée' : 'Supprimer'">
         </button>
       </td>
     </tr>


### PR DESCRIPTION
- Replace 'tooltip' with 'pTooltip' for all buttons in reservations table
- Fixes Angular binding error NG8002
- PrimeNG uses 'pTooltip' directive, not standard 'tooltip' attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)