### PR TITLE
fix: Remove document field references from passagers component TypeSc…

### DIFF
--- a/src/app/features/passagers/passagers.component.ts
+++ b/src/app/features/passagers/passagers.component.ts
@@ -42,11 +42,10 @@ export class PassagersComponent {
       this.passagersService.update(this.currentId, this.form);
     } else {
       // Create new
-      if (this.form.nom && this.form.telephone && this.form.document) {
+      if (this.form.nom && this.form.telephone) {
         this.passagersService.create({
           nom: this.form.nom,
-          telephone: this.form.telephone,
-          document: this.form.document
+          telephone: this.form.telephone
         });
       }
     }


### PR DESCRIPTION
…ript

- Remove 'document' validation from save() method condition
- Remove 'document' property from passagersService.create() call
- Fixes TypeScript errors TS2339 and TS2353
- Aligns TypeScript code with updated Passager interface

This completes the removal of the document field from passagers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)