### PR TITLE
fix: Improve MRU currency display format

### DIFF
--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -42,7 +42,7 @@
       </div>
       <div class="kpi-content">
         <h3 class="kpi-title">Revenus du mois</h3>
-        <div class="kpi-value">{{ kpis().revenueMonth | currency:'MRU' }}</div>
+        <div class="kpi-value">{{ kpis().revenueMonth | number:'1.2-2' }} MRU</div>
         <p class="kpi-description">Chiffre d'affaires mensuel</p>
         <button pButton label="Voir les rapports" icon="pi pi-arrow-right"
                 iconPos="right" class="kpi-action" routerLink="/rapports" severity="warn"></button>

--- a/src/app/features/paiements/paiements.component.html
+++ b/src/app/features/paiements/paiements.component.html
@@ -11,7 +11,7 @@
     <tr>
       <td>{{ p.ref }}</td>
       <td>{{ p.type }}</td>
-      <td>{{ p.montant | currency:'MRU' }}</td>
+      <td>{{ p.montant | number:'1.2-2' }} MRU</td>
       <td>{{ p.mode }}</td>
       <td>{{ p.note }}</td>
       <td>

--- a/src/app/features/rapports/rapports.component.html
+++ b/src/app/features/rapports/rapports.component.html
@@ -1,12 +1,12 @@
 <div class="grid" style="row-gap:1rem">
   <div class="col-12 md:col-4">
     <p-card header="Ventes billets (mois)">
-      <div class="text-2xl font-bold">{{ kpis().billets | currency:'MRU' }}</div>
+      <div class="text-2xl font-bold">{{ kpis().billets | number:'1.2-2' }} MRU</div>
     </p-card>
   </div>
   <div class="col-12 md:col-4">
     <p-card header="Ventes colis (mois)">
-      <div class="text-2xl font-bold">{{ kpis().colis | currency:'MRU' }}</div>
+      <div class="text-2xl font-bold">{{ kpis().colis | number:'1.2-2' }} MRU</div>
     </p-card>
   </div>
   <div class="col-12 md:col-4">

--- a/src/app/features/reservations/reservations.component.html
+++ b/src/app/features/reservations/reservations.component.html
@@ -18,7 +18,7 @@
       <td>{{ r.passager }}</td>
       <td>{{ r.trajet }}</td>
       <td>{{ r.date | date:'shortDate' }}</td>
-      <td>{{ r.prix | currency:'MRU' }}</td>
+      <td>{{ r.prix | number:'1.2-2' }} MRU</td>
       <td><p-tag [value]="r.statut" [severity]="r.statut==='Validée' ? 'success' : 'warning'"/></td>
       <td class="flex gap-2">
         <button pButton icon="pi pi-pencil" (click)="edit(r)"></button>


### PR DESCRIPTION
Changed from currency pipe (MRU555.00) to number pipe with suffix (555.00 MRU) for better readability.

Files updated:
- reservations.component.html: Prix display
- paiements.component.html: Montant display
- rapports.component.html: KPIs billets and colis
- dashboard.component.html: Revenue KPI

Now displays as "555.00 MRU" instead of "MRU555.00"

🤖 Generated with [Claude Code](https://claude.com/claude-code)