### PR TITLE
fix: Add DecimalPipe imports for number pipe usage

### DIFF
--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, computed } from '@angular/core';
 import { CardModule } from 'primeng/card';
 import { ButtonModule } from 'primeng/button';
 import { RouterModule } from '@angular/router';
-import { CurrencyPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { ReservationsService } from '../../core/services/reservations.service';
 import { ColisService } from '../../core/services/colis.service';
 import { PaiementsService } from '../../core/services/paiements.service';
@@ -10,7 +10,7 @@ import { PaiementsService } from '../../core/services/paiements.service';
 @Component({
   standalone: true,
   selector: 'app-dashboard',
-  imports: [CardModule, ButtonModule, RouterModule, CurrencyPipe],
+  imports: [CardModule, ButtonModule, RouterModule, DecimalPipe],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })

--- a/src/app/features/paiements/paiements.component.ts
+++ b/src/app/features/paiements/paiements.component.ts
@@ -5,13 +5,13 @@ import { InputTextModule } from 'primeng/inputtext';
 import { InputNumberModule } from 'primeng/inputnumber';
 import { ButtonModule } from 'primeng/button';
 import { FormsModule } from '@angular/forms';
-import { CurrencyPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { PaiementsService } from '../../core/services/paiements.service';
 
 @Component({
   standalone: true,
   selector: 'app-paiements',
-  imports: [TableModule, DialogModule, InputTextModule, InputNumberModule, ButtonModule, FormsModule, CurrencyPipe],
+  imports: [TableModule, DialogModule, InputTextModule, InputNumberModule, ButtonModule, FormsModule, DecimalPipe],
   templateUrl: './paiements.component.html',
   styleUrls: ['./paiements.component.css']
 })

--- a/src/app/features/rapports/rapports.component.ts
+++ b/src/app/features/rapports/rapports.component.ts
@@ -1,13 +1,13 @@
 import { Component, inject } from '@angular/core';
 import { CardModule } from 'primeng/card';
-import { CurrencyPipe, DecimalPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { TableModule } from 'primeng/table';
 import { RapportsService } from '../../core/services/rapports.service';
 
 @Component({
   standalone: true,
   selector: 'app-rapports',
-  imports: [CardModule, TableModule, DecimalPipe, CurrencyPipe],
+  imports: [CardModule, TableModule, DecimalPipe],
   templateUrl: './rapports.component.html',
   styleUrls: ['./rapports.component.css']
 })

--- a/src/app/features/reservations/reservations.component.ts
+++ b/src/app/features/reservations/reservations.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, computed } from '@angular/core';
-import { DatePipe, CurrencyPipe, CommonModule } from '@angular/common';
+import { DatePipe, DecimalPipe, CommonModule } from '@angular/common';
 import { TableModule } from 'primeng/table';
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
@@ -19,7 +19,7 @@ import { AuthService } from '../../auth/auth.service';
 @Component({
   standalone: true,
   selector: 'app-reservations',
-  imports: [TableModule, DialogModule, InputTextModule, Select, DatePicker, ButtonModule, TagModule, FormsModule, InputNumberModule, TooltipModule, DatePipe, CurrencyPipe, CommonModule, TicketPrintComponent],
+  imports: [TableModule, DialogModule, InputTextModule, Select, DatePicker, ButtonModule, TagModule, FormsModule, InputNumberModule, TooltipModule, DatePipe, DecimalPipe, CommonModule, TicketPrintComponent],
   templateUrl: './reservations.component.html',
   styleUrls: ['./reservations.component.css']
 })


### PR DESCRIPTION
Replaced CurrencyPipe with DecimalPipe in all components using the number pipe. This fixes the Angular compilation errors:
- NG8004: No pipe found with name 'number'
- NG8113: CurrencyPipe is not used within template

Files updated:
- dashboard.component.ts: Import DecimalPipe instead of CurrencyPipe
- paiements.component.ts: Import DecimalPipe instead of CurrencyPipe
- rapports.component.ts: Remove unused CurrencyPipe
- reservations.component.ts: Import DecimalPipe instead of CurrencyPipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)