### PR TITLE
feat: Configure Angular to accept external hosts for Cloudflare Tunnel

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,6 +54,10 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "host": "0.0.0.0",
+            "allowedHosts": ["all"]
+          },
           "configurations": {
             "production": {
               "buildTarget": "qafilti-ui:build:production"


### PR DESCRIPTION
Added configuration to allow Angular dev server to accept connections from external hosts like Cloudflare Tunnel URLs.

Changes:
- angular.json: Added serve options with host "0.0.0.0" and allowedHosts ["all"]
- This fixes "Blocked request" error when accessing via Cloudflare Tunnel
- Enables public access to localhost:4200 through tunnel URLs

Configuration added:
- host: "0.0.0.0" - Listen on all network interfaces
- allowedHosts: ["all"] - Accept requests from any host (including Cloudflare domains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)