### PR TITLE
revert: Remove Cloudflare Tunnel configuration from angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,10 +54,6 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
-          "options": {
-            "host": "0.0.0.0",
-            "allowedHosts": ["all"]
-          },
           "configurations": {
             "production": {
               "buildTarget": "qafilti-ui:build:production"


### PR DESCRIPTION
Removed the external host configuration that was added for Cloudflare Tunnel. The application will now only accept connections from localhost by default.

Changes reverted:
- Removed "host": "0.0.0.0"
- Removed "allowedHosts": ["all"]

The configuration can be re-added manually if needed for public access via tunneling services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)